### PR TITLE
v0.3.0

### DIFF
--- a/.gitattributes
+++ b/.gitattributes
@@ -1,5 +1,5 @@
-# Files to ignore in distributions
 examples export-ignore
+tests export-ignore
 .gitattributes export-ignore
 .gitignore export-ignore
 .travis.yml export-ignore

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,19 @@
 # Changelog
 
+### v0.3.0
+
+- Changes
+    - The following methods now return a `Generator` that can be used to create a `Coroutine` instead of returning a promise. Wrap the function call with `new Coroutine()` to create a promise or use with `yield` in a coroutine. This change was made to support `yield from` in PHP 7.
+        - `Icicle\Dns\Executor\ExecutorInterface::execute()`
+        - `Icicle\Dns\Resolver\ResolverInterface::resolve()`
+
+### v0.2.0
+
+- Changes
+    - Update for API changes made in Icicle v0.5.0.
+
+---
+
 ### v0.1.2
 
 - Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v0.3.0
+
+- Changes
+    - The following methods now return a `Generator` that can be used to create a `Coroutine` instead of returning a promise. Wrap the function call with `new Coroutine()` to create a promise or use with `yield` in a coroutine. This change was made to support `yield from` in PHP 7.
+        - `Icicle\Dns\Executor\ExecutorInterface::execute()`
+        - `Icicle\Dns\Resolver\ResolverInterface::resolve()`
+
 ### v0.2.0
 
 - Changes

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 # Changelog
 
+### v0.2.0
+
+- Changes
+    - Update for API changes made in Icicle v0.5.0.
+
+---
+
 ### v0.1.2
 
 - Changes

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,3 +1,3 @@
 # Contributing
 
-**Icicle (icicle.io)** is an open-source project and welcomes contributions from the community. Please see our [contributing guidelines](//github.com/icicleio/Icicle/blob/master/CONTRIBUTING.md) in the [Icicle repository](//github.com/icicleio/Icicle).
+**Icicle (icicle.io)** is an open-source project and welcomes contributions from the community. Please see our [contributing guidelines](https://github.com/icicleio/Icicle/blob/master/CONTRIBUTING.md) in the [Icicle repository](https://github.com/icicleio/Icicle).

--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@ This library is a component for [Icicle](//github.com/icicleio/Icicle), providin
 [![@icicleio on Twitter](https://img.shields.io/badge/twitter-%40icicleio-5189c7.svg?style=flat-square)](https://twitter.com/icicleio)
 [![Build Status](https://img.shields.io/travis/icicleio/Dns/master.svg?style=flat-square)](https://travis-ci.org/icicleio/Dns)
 [![Coverage Status](https://img.shields.io/coveralls/icicleio/Dns.svg?style=flat-square)](https://coveralls.io/r/icicleio/Dns)
-[![Semantic Version](https://img.shields.io/badge/semver-v0.1.2-yellow.svg?style=flat-square)](http://semver.org)
+[![Semantic Version](https://img.shields.io/badge/semver-v0.2.0-yellow.svg?style=flat-square)](http://semver.org)
 [![Apache 2 License](https://img.shields.io/packagist/l/icicleio/dns.svg?style=flat-square)](LICENSE)
 
 [![Join the chat at https://gitter.im/icicleio/Icicle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/icicleio/Icicle)
@@ -30,7 +30,7 @@ You can also manually edit `composer.json` to add this library as a project requ
 // composer.json
 {
     "require": {
-        "icicleio/dns": "0.1.*"
+        "icicleio/dns": "0.2.*"
     }
 }
 ```
@@ -42,7 +42,7 @@ The example below uses a resolver to asynchronously find the IP address for the 
 ```php
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 $resolver = new Resolver(new Executor('8.8.8.8'));
 
@@ -59,7 +59,7 @@ $promise->then(
     }
 );
 
-Loop::run();
+Loop\run();
 ```
 
 ## Documentation
@@ -133,7 +133,7 @@ Below is an example of how an executor can be used to find the NS records for a 
 
 ```php
 use Icicle\Dns\Executor\Executor;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use LibDNS\Messages\Message;
 
 $executor = new Executor('8.8.8.8');
@@ -151,7 +151,7 @@ $promise->then(
     }
 );
 
-Loop::run();
+Loop\run();
 ```
 
 ### MultiExecutor
@@ -161,7 +161,7 @@ The `Icicle\Dns\Executor\MultiExecutor` class can be used to combine multiple ex
 ```php
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Executor\MultiExecutor;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use LibDNS\Messages\Message;
 
 $executor = new MultiExecutor();
@@ -183,7 +183,7 @@ $promise->then(
     }
 );
 
-Loop::run();
+Loop\run();
 ```
 
 Queries using the above executor will automatically send requests to the second name server if the first does not respond. Subsequent queries are initially sent to the last server that successfully responded to a query.
@@ -209,7 +209,7 @@ The `Icicle\Resolver\Resolver` class is constructed by passing an `Icicle\Execut
 ```php
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 $resolver = new Resolver(new Executor('8.8.8.8'));
 
@@ -226,7 +226,7 @@ $promise->then(
     }
 );
 
-Loop::run();
+Loop\run();
 ```
 
 ## Connector
@@ -253,7 +253,7 @@ PromiseInterface $connectorInterface->connect(
 use Icicle\Dns\Connector\Connector;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Socket\Client\ClientInterface;
 
 $connector = new Connector(new Resolver(new Executor('8.8.8.8')));
@@ -270,5 +270,5 @@ $promise->then(
     }
 );
 
-Loop::run();
+Loop\run();
 ```

--- a/README.md
+++ b/README.md
@@ -1,11 +1,11 @@
 # Asynchronous DNS for Icicle
 
-This library is a component for [Icicle](//github.com/icicleio/Icicle), providing an asynchronous DNS query executor, resolver, and client connector. An asynchronous DNS server is currently under development and will be added to this component in the future. Like other Icicle components, this library returns [promises](//github.com/icicleio/Icicle/wiki/Promises) from asynchronous operations that may be used to build [coroutines](//github.com/icicleio/Icicle/wiki/Coroutines) to make writing asynchronous code more like writing synchronous code.
+This library is a component for [Icicle](https://github.com/icicleio/Icicle), providing an asynchronous DNS query executor, resolver, and client connector. An asynchronous DNS server is currently under development and will be added to this component in the future. Like other Icicle components, this library uses [Promises](https://github.com/icicleio/Icicle/wiki/Promises) and [Generators](http://www.php.net/manual/en/language.generators.overview.php) for asynchronous operations that may be used to build [Coroutines](//github.com/icicleio/Icicle/wiki/Coroutines) to make writing asynchronous code more like writing synchronous code.
 
 [![@icicleio on Twitter](https://img.shields.io/badge/twitter-%40icicleio-5189c7.svg?style=flat-square)](https://twitter.com/icicleio)
 [![Build Status](https://img.shields.io/travis/icicleio/Dns/master.svg?style=flat-square)](https://travis-ci.org/icicleio/Dns)
 [![Coverage Status](https://img.shields.io/coveralls/icicleio/Dns.svg?style=flat-square)](https://coveralls.io/r/icicleio/Dns)
-[![Semantic Version](https://img.shields.io/badge/semver-v0.2.0-yellow.svg?style=flat-square)](http://semver.org)
+[![Semantic Version](https://img.shields.io/badge/semver-v0.3.0-yellow.svg?style=flat-square)](http://semver.org)
 [![Apache 2 License](https://img.shields.io/packagist/l/icicleio/dns.svg?style=flat-square)](LICENSE)
 
 [![Join the chat at https://gitter.im/icicleio/Icicle](https://badges.gitter.im/Join%20Chat.svg)](https://gitter.im/icicleio/Icicle)
@@ -30,7 +30,7 @@ You can also manually edit `composer.json` to add this library as a project requ
 // composer.json
 {
     "require": {
-        "icicleio/dns": "0.2.*"
+        "icicleio/dns": "0.3.*"
     }
 }
 ```
@@ -46,18 +46,19 @@ use Icicle\Loop;
 
 $resolver = new Resolver(new Executor('8.8.8.8'));
 
-$promise = $resolver->resolve('icicle.io');
-
-$promise->then(
-    function (array $ips) {
+$generator = function ($domain) use ($resolver) {
+    try {
+        $ips = (yield $resolver->resolve($domain));
+        
         foreach ($ips as $ip) {
             echo "IP: {$ip}\n";
         }
-    },
-    function (Exception $exception) {
+    } catch (Exception $exception) {
         echo "Error when executing query: {$exception->getMessage()}\n";
     }
-);
+};
+
+$coroutine = new Coroutine($generator('icicle.io'));
 
 Loop\run();
 ```
@@ -71,7 +72,9 @@ Loop\run();
 - [Resolver](#resolver) - Resolves the IP address for a domain name.
 - [Connector](#connector) - Connects to a host and port.
 
-All references to `PromiseInterface` in the documentation below are to `Icicle\Promise\PromiseInterface`, part of the promises component of [Icicle](//github.com/icicleio/Icicle). For more information on promises, see the [Promise API documentation](//github.com/icicleio/Icicle/wiki/Promises) for more information.
+All references to `PromiseInterface` in the documentation below are to `Icicle\Promise\PromiseInterface`, part of the promises component of [Icicle](https://github.com/icicleio/Icicle). For more information on promises, see the [Promise API documentation](https://github.com/icicleio/Icicle/wiki/Promises) for more information.
+
+Methods returning a `Generator` can be used to create a [Coroutine](https://github.com/icicleio/Icicle/wiki/Coroutines) (e.g., `new Coroutine($executor->execute(...))`) or yielded within another Coroutine (use `yield from` in PHP 7 for better performance).
 
 This library uses [LibDNS](//github.com/DaveRandom/LibDNS) to create and parse DNS messages. Unfortunately the documentation for this library is currently limited to DocComments in the source code. If using only the resolver and connector components of this library, there is no need to worry about how this library works. The executor component returns promises that are resolved with `LibDNS\Messages\Message` instances, representing the response from the DNS server. Using these objects is simple and will be described in the executor section below.
 
@@ -90,7 +93,7 @@ Executors are the foundation of the DNS component, performing any DNS query and 
 Each executor implements `Icicle\Dns\Executor\ExecutorInterface` that defines a single method, `execute()`.
 
 ```php
-PromiseInterface $executorInterface->execute(
+Generator $executorInterface->execute(
     string $domain,
     string|int $type,
     float|int $timeout = 2,
@@ -132,15 +135,16 @@ DNS records in the traversable `LibDNS\Records\RecordCollection` objects are rep
 Below is an example of how an executor can be used to find the NS records for a domain.
 
 ```php
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Loop;
 use LibDNS\Messages\Message;
 
 $executor = new Executor('8.8.8.8');
 
-$promise = $executor->execute('google.com', 'NS');
+$coroutine = new Coroutine($executor->execute('google.com', 'NS'));
 
-$promise->then(
+$coroutine->then(
     function (Message $message) {
         foreach ($message->getAnswerRecords() as $resource) {
             echo "TTL: {$resource->getTTL()} Value: {$resource->getData()}\n";
@@ -159,6 +163,7 @@ Loop\run();
 The `Icicle\Dns\Executor\MultiExecutor` class can be used to combine multiple executors to send queries to several name servers so queries can be resolved even if some name servers stop responding.
 
 ```php
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Executor\MultiExecutor;
 use Icicle\Loop;
@@ -170,9 +175,9 @@ $executor->add(new Executor('8.8.8.8'));
 $executor->add(new Executor('8.8.4.4'));
 
 // Executor will send query to 8.8.4.4 if 8.8.8.8 does not respond.
-$promise = $executor->execute('google.com', 'MX');
+$coroutine = new Coroutine($executor->execute('google.com', 'MX'));
 
-$promise->then(
+$coroutine->then(
     function (Message $message) {
         foreach ($message->getAnswerRecords() as $resource) {
             echo "TTL: {$resource->getTTL()} Value: {$resource->getData()}\n";
@@ -193,7 +198,7 @@ Queries using the above executor will automatically send requests to the second 
 A resolver finds the IP addresses for a given domain. `Icicle\Dns\Resolver\Resolver` implements `Icicle\Dns\Resolver\ResolverInterface`, which defines a single method, `resolve()`. A resolver is essentially a specialized executor that performs only `A` queries, fulfilling the promise returned from `resolve()` with an array of IP addresses (even if only one IP address is found, the promise is still resolved with an array).
 
 ```php
-PromiseInterface $resolverInterface->resolve(
+Generator $resolverInterface->resolve(
     string $domain,
     float|int $timeout = 2,
     int $retries = 5
@@ -207,15 +212,16 @@ The `Icicle\Resolver\Resolver` class is constructed by passing an `Icicle\Execut
 ##### Example
 
 ```php
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
 use Icicle\Loop;
 
 $resolver = new Resolver(new Executor('8.8.8.8'));
 
-$promise = $resolver->resolve('google.com');
+$coroutine = new Coroutine($resolver->resolve('google.com'));
 
-$promise->then(
+$coroutine->then(
     function (array $ips) {
         foreach ($ips as $ip) {
             echo "IP: {$ip}\n";

--- a/composer.json
+++ b/composer.json
@@ -1,6 +1,6 @@
 {
     "name": "icicleio/dns",
-    "description": "Asynchronous DNS resolver for Icicle.",
+    "description": "Asynchronous DNS for Icicle.",
     "keywords": [
         "dns",
         "resolver",
@@ -16,7 +16,7 @@
         }
     ],
     "require": {
-        "icicleio/icicle": "0.2 - 0.4",
+        "icicleio/icicle": "~0.5",
         "daverandom/libdns": "~1"
     },
     "require-dev": {
@@ -27,8 +27,8 @@
     },
     "extra": {
         "branch-alias": {
-            "dev-master": "0.1-dev",
-            "dev-development": "0.2-dev"
+            "dev-master": "0.2-dev",
+            "dev-development": "0.3-dev"
         }
     },
     "autoload": {
@@ -38,7 +38,6 @@
     },
     "autoload-dev": {
         "psr-4": {
-            "Icicle\\Tests\\": "vendor/icicleio/icicle/tests",
             "Icicle\\Tests\\Dns\\": "tests"
         }
     }

--- a/examples/connect.php
+++ b/examples/connect.php
@@ -3,15 +3,15 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Icicle\Coroutine\Coroutine;
+use Icicle\Coroutine;
 use Icicle\Dns\Connector\Connector;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
-$timer = Loop::periodic(0.01, function () { echo "Waiting... " . microtime(true) . "\n"; });
+$timer = Loop\periodic(0.01, function () { echo "Waiting... " . microtime(true) . "\n"; });
 
-$coroutine = Coroutine::call(function () {
+$coroutine = Coroutine\create(function () {
     echo "Connecting to google.com...\n";
     
     $connector = new Connector(new Resolver(new Executor('8.8.8.8')));
@@ -46,4 +46,4 @@ $coroutine
     }
 );
 
-Loop::run();
+Loop\run();

--- a/examples/execute.php
+++ b/examples/execute.php
@@ -3,12 +3,11 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Icicle\Coroutine\Coroutine;
-use Icicle\Dns\Executor\CachingExecutor;
+use Icicle\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Executor\ExecutorInterface;
 use Icicle\Dns\Executor\MultiExecutor;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 if (3 > $argc) {
     throw new InvalidArgumentException('Too few arguments provided. Usage: {DomainName} {RecordType}');
@@ -17,7 +16,7 @@ if (3 > $argc) {
 $domain = $argv[1];
 $type = $argv[2];
 
-$coroutine = Coroutine::call(function ($query, $type, $timeout = ExecutorInterface::DEFAULT_TIMEOUT) {
+$coroutine = Coroutine\create(function ($query, $type, $timeout = ExecutorInterface::DEFAULT_TIMEOUT) {
     $executor = new MultiExecutor();
     $executor->add(new Executor('8.8.8.8'));
     $executor->add(new Executor('8.8.4.4'));
@@ -47,4 +46,4 @@ $coroutine->capture(function (Exception $e) {
     echo "Exception of type {$class}: {$e->getMessage()}\n";
 });
 
-Loop::run();
+Loop\run();

--- a/examples/resolve.php
+++ b/examples/resolve.php
@@ -3,10 +3,10 @@
 
 require dirname(__DIR__) . '/vendor/autoload.php';
 
-use Icicle\Coroutine\Coroutine;
+use Icicle\Coroutine;
 use Icicle\Dns\Executor\Executor;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 
 if (2 > $argc) {
     throw new InvalidArgumentException('Too few arguments provided. Usage: {DomainName}');
@@ -14,7 +14,7 @@ if (2 > $argc) {
 
 $domain = $argv[1];
 
-$coroutine = Coroutine::call(function ($query, $timeout = 1) {
+$coroutine = Coroutine\create(function ($query, $timeout = 1) {
     echo "Query: {$query}:\n";
     
     $resolver = new Resolver(new Executor('8.8.8.8'));
@@ -30,4 +30,4 @@ $coroutine->capture(function (Exception $e) {
     echo "Exception: {$e->getMessage()}\n";
 });
 
-Loop::run();
+Loop\run();

--- a/src/Connector/Connector.php
+++ b/src/Connector/Connector.php
@@ -49,9 +49,9 @@ class Connector implements ConnectorInterface
         }
 
         $default = ['name' => $domain];
-        $options = is_array($options) ? array_merge($default, $options) : $default;
+        $options = null === $options ? $default : array_merge($default, $options);
 
-        return new Coroutine($this->run($domain, $port, $timeout, $retries, $options));
+        return new Coroutine($this->doConnect($domain, $port, $timeout, $retries, $options));
     }
 
     /**
@@ -69,7 +69,7 @@ class Connector implements ConnectorInterface
      *
      * @reject  \Icicle\Socket\Exception\FailureException
      */
-    protected function run($domain, $port, $timeout, $retries, array $options)
+    private function doConnect($domain, $port, $timeout, $retries, array $options)
     {
         $ips = (yield $this->resolver->resolve($domain, $timeout, $retries));
 

--- a/src/Executor/Executor.php
+++ b/src/Executor/Executor.php
@@ -134,46 +134,6 @@ class Executor implements ExecutorInterface
             $retries = 0;
         }
 
-        return new Coroutine($this->run($name, $type, $timeout, $retries));
-    }
-
-    /**
-     * IP address of the name server used by this executor.
-     *
-     * @return  string
-     */
-    public function getAddress()
-    {
-        return $this->address;
-    }
-
-    /**
-     * @return  int
-     */
-    public function getPort()
-    {
-        return $this->port;
-    }
-
-    /**
-     * @coroutine
-     *
-     * @param   string $name Domain name.
-     * @param   string|int $type Record type (e.g., 'A', 'MX', 'AAAA', 'NS' or integer value of type)
-     * @param   float|int $timeout Seconds until a request times out.
-     * @param   int $retries Number of times to attempt the request.
-     *
-     * @return  \Generator
-     *
-     * @resolve \LibDNS\Messages\Message
-     *
-     * @reject  \Icicle\Dns\Exception\FailureException If the server responds with a non-zero response code or does
-     *          not respond at all.
-     * @reject  \Icicle\Dns\Exception\NotFoundException If a record for the given query is not found.
-     * @reject  \Icicle\Dns\Exception\MessageException If there is a problem with the response or no response.
-     */
-    protected function run($name, $type, $timeout, $retries)
-    {
         $question = $this->createQuestion($name, $type);
 
         $request = $this->createRequest($question);
@@ -217,6 +177,24 @@ class Executor implements ExecutorInterface
         } finally {
             $client->close();
         }
+    }
+
+    /**
+     * IP address of the name server used by this executor.
+     *
+     * @return  string
+     */
+    public function getAddress()
+    {
+        return $this->address;
+    }
+
+    /**
+     * @return  int
+     */
+    public function getPort()
+    {
+        return $this->port;
     }
 
     /**

--- a/src/Executor/ExecutorInterface.php
+++ b/src/Executor/ExecutorInterface.php
@@ -7,12 +7,14 @@ interface ExecutorInterface
     const DEFAULT_RETRIES = 5;
     
     /**
+     * @coroutine
+     *
      * @param   string $name Domain name.
      * @param   string|int $type Query type (e.g., 'A', 'MX', 'AAAA', 'NS')
      * @param   float|int $timeout Timeout for each individual request.
      * @param   int $retries Number of times to retry the request until failing.
      *
-     * @return  \Icicle\Promise\PromiseInterface
+     * @return  \Generator
      *
      * @resolve \LibDNS\Messages\Message Response message.
      *

--- a/src/Executor/MultiExecutor.php
+++ b/src/Executor/MultiExecutor.php
@@ -36,29 +36,7 @@ class MultiExecutor implements ExecutorInterface
         if (0 > $retries) {
             $retries = 0;
         }
-        
-        return new Coroutine($this->run($name, $type, $timeout, $retries));
-    }
 
-    /**
-     * @coroutine
-     *
-     * @param   string $name Domain name.
-     * @param   string|int $type Record type (e.g., 'A', 'MX', 'AAAA', 'NS' or integer value of type)
-     * @param   float|int $timeout Seconds until a request times out.
-     * @param   int $retries Number of times to attempt the request.
-     *
-     * @return  \Generator
-     *
-     * @resolve \LibDNS\Messages\Message
-     *
-     * @reject  \Icicle\Dns\Exception\LogicException If no executors are defined.
-     * @reject  \Icicle\Dns\Exception\FailureException If the server responds with a non-zero response code or does
-     *          not respond at all.
-     * @reject  \Icicle\Dns\Exception\MessageException If there is a problem with the response or no response.
-     */
-    protected function run($name, $type, $timeout, $retries)
-    {
         if ($this->executors->isEmpty()) {
             throw new LogicException('No executors defined.');
         }

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -4,7 +4,7 @@ namespace Icicle\Dns\Resolver;
 use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Exception\NotFoundException;
 use Icicle\Dns\Executor\ExecutorInterface;
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use LibDNS\Records\ResourceTypes;
 
 class Resolver implements ResolverInterface
@@ -31,23 +31,10 @@ class Resolver implements ResolverInterface
         $retries = ExecutorInterface::DEFAULT_RETRIES
     ) {
         if (strtolower($domain) === 'localhost') {
-            return Promise::resolve(['127.0.0.1']);
+            yield ['127.0.0.1'];
+            return;
         }
 
-        return new Coroutine($this->run($domain, $timeout, $retries));
-    }
-
-    /**
-     * @coroutine
-     *
-     * @param   string $domain
-     * @param   float|int $timeout
-     * @param   int $retries
-     *
-     * @return  \Generator
-     */
-    protected function run($domain, $timeout, $retries)
-    {
         /** @var \LibDNS\Messages\Message $response */
         $response = (yield $this->executor->execute($domain, ResourceTypes::A, $timeout, $retries));
 

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -4,7 +4,7 @@ namespace Icicle\Dns\Resolver;
 use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Exception\NotFoundException;
 use Icicle\Dns\Executor\ExecutorInterface;
-use Icicle\Promise\Promise;
+use Icicle\Promise;
 use LibDNS\Records\ResourceTypes;
 
 class Resolver implements ResolverInterface
@@ -31,7 +31,7 @@ class Resolver implements ResolverInterface
         $retries = ExecutorInterface::DEFAULT_RETRIES
     ) {
         if (strtolower($domain) === 'localhost') {
-            return Promise::resolve(['127.0.0.1']);
+            return Promise\resolve(['127.0.0.1']);
         }
 
         return new Coroutine($this->run($domain, $timeout, $retries));

--- a/src/Resolver/Resolver.php
+++ b/src/Resolver/Resolver.php
@@ -31,23 +31,10 @@ class Resolver implements ResolverInterface
         $retries = ExecutorInterface::DEFAULT_RETRIES
     ) {
         if (strtolower($domain) === 'localhost') {
-            return Promise\resolve(['127.0.0.1']);
+            yield ['127.0.0.1'];
+            return;
         }
 
-        return new Coroutine($this->run($domain, $timeout, $retries));
-    }
-
-    /**
-     * @coroutine
-     *
-     * @param   string $domain
-     * @param   float|int $timeout
-     * @param   int $retries
-     *
-     * @return  \Generator
-     */
-    protected function run($domain, $timeout, $retries)
-    {
         /** @var \LibDNS\Messages\Message $response */
         $response = (yield $this->executor->execute($domain, ResourceTypes::A, $timeout, $retries));
 

--- a/src/Resolver/ResolverInterface.php
+++ b/src/Resolver/ResolverInterface.php
@@ -6,11 +6,13 @@ use Icicle\Dns\Executor\ExecutorInterface;
 interface ResolverInterface
 {
     /**
+     * @coroutine
+     *
      * @param   string $domain Domain name to resolve.
      * @param   int|float $timeout Time until a request fails
      * @param   int $retries Number of times to retry the request until failing.
      *
-     * @return  \Icicle\Promise\PromiseInterface
+     * @return  \Generator
      *
      * @resolve string[] List of IP address. Will always contain at least one IP, otherwise the promise is rejected.
      *

--- a/tests/Connector/ConnectorTest.php
+++ b/tests/Connector/ConnectorTest.php
@@ -2,8 +2,8 @@
 namespace Icicle\Tests\Dns\Connector;
 
 use Icicle\Dns\Connector\Connector;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Exception\FailureException;
 use Icicle\Socket\Exception\TimeoutException;
 use Icicle\Tests\Dns\TestCase;
@@ -60,7 +60,7 @@ class ConnectorTest extends TestCase
 
         $this->clientConnector->shouldReceive('connect')
             ->with(Mockery::mustBe($ips[0]), Mockery::mustBe($port), Mockery::type('array'))
-            ->andReturn(Promise::resolve(Mockery::mock('Icicle\Socket\Client\ClientInterface')));
+            ->andReturn(Promise\resolve(Mockery::mock('Icicle\Socket\Client\ClientInterface')));
 
         $promise = $this->connector->connect($domain, $port, $options, $timeout, $retries);
 
@@ -70,7 +70,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -91,7 +91,7 @@ class ConnectorTest extends TestCase
 
         $this->clientConnector->shouldReceive('connect')
             ->with(Mockery::mustBe($ips[0]), Mockery::mustBe($port), Mockery::type('array'))
-            ->andReturn(Promise::reject(new TimeoutException()));
+            ->andReturn(Promise\reject(new TimeoutException()));
 
         $promise = $this->connector->connect($domain, $port, $options, $timeout, $retries);
 
@@ -101,7 +101,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -123,9 +123,9 @@ class ConnectorTest extends TestCase
                 static $initial = true;
                 if ($initial) {
                     $initial = false;
-                    return Promise::reject(new FailureException());
+                    return Promise\reject(new FailureException());
                 }
-                return Promise::resolve(Mockery::mock('Icicle\Socket\Client\ClientInterface'));
+                return Promise\resolve(Mockery::mock('Icicle\Socket\Client\ClientInterface'));
             });
 
         $promise = $this->connector->connect($domain, $port);
@@ -136,7 +136,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -159,7 +159,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($this->createCallback(1), $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -187,7 +187,7 @@ class ConnectorTest extends TestCase
 
         $this->clientConnector->shouldReceive('connect')
             ->with(Mockery::mustBe($ip), Mockery::mustBe($port), Mockery::any())
-            ->andReturn(Promise::resolve($this->getMock('Icicle\Socket\Client\ClientInterface')));
+            ->andReturn(Promise\resolve($this->getMock('Icicle\Socket\Client\ClientInterface')));
 
         $promise = $this->connector->connect($ip, $port);
 
@@ -197,7 +197,7 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -225,7 +225,7 @@ class ConnectorTest extends TestCase
 
         $this->clientConnector->shouldReceive('connect')
             ->with(Mockery::mustBe($ip), Mockery::mustBe($port), Mockery::any())
-            ->andReturn(Promise::resolve($this->getMock('Icicle\Socket\Client\ClientInterface')));
+            ->andReturn(Promise\resolve($this->getMock('Icicle\Socket\Client\ClientInterface')));
 
         $promise = $this->connector->connect($ip, $port);
 
@@ -235,6 +235,6 @@ class ConnectorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -4,8 +4,8 @@ namespace Icicle\Tests\Dns\Executor;
 use Icicle\Dns\Exception\InvalidTypeException;
 use Icicle\Dns\Exception\ResponseIdException;
 use Icicle\Dns\Executor\Executor;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Socket\Client\ClientInterface;
 use Icicle\Socket\Exception\TimeoutException;
 use Icicle\Tests\Dns\TestCase;
@@ -97,7 +97,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testInvalidStringType()
@@ -115,7 +115,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function execute($type, $domain, $request, $response, array $answers = null, array $authority = null)
@@ -129,7 +129,7 @@ class ExecutorTest extends TestCase
 
         $this->client->shouldReceive('read')
             ->andReturnUsing(function () use (&$id, $response) {
-                return Promise::resolve($id . substr(base64_decode($response), self::ID_LENGTH));
+                return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
         $promise = $this->executor->execute($domain, $type);
@@ -158,7 +158,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -199,7 +199,7 @@ class ExecutorTest extends TestCase
 
         $this->client->shouldReceive('read')
             ->andReturnUsing(function () use (&$id, $response) {
-                return Promise::resolve($id . substr(base64_decode($response), 2));
+                return Promise\resolve($id . substr(base64_decode($response), 2));
             });
 
         $promise = $this->executor->execute($domain, 'A');
@@ -210,7 +210,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -230,7 +230,7 @@ class ExecutorTest extends TestCase
                 $id = unpack('n', $id)[1];
                 $id += 1;
                 $id = pack('n', $id);
-                return Promise::resolve($id . substr(base64_decode($response), self::ID_LENGTH));
+                return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
         $promise = $this->executor->execute($domain, 'NS');
@@ -245,18 +245,18 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testEmptyStringReceivedAsResponse()
     {
         $this->client->shouldReceive('write')
             ->andReturnUsing(function ($data) {
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             });
 
         $this->client->shouldReceive('read')
-            ->andReturn(Promise::resolve(''));
+            ->andReturn(Promise\resolve(''));
 
         $promise = $this->executor->execute('example.com', 'A');
 
@@ -266,7 +266,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -276,17 +276,17 @@ class ExecutorTest extends TestCase
     {
         $this->client->shouldReceive('write')
             ->andReturnUsing(function ($data) {
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             });
 
         $this->client->shouldReceive('read')
-            ->andReturn(Promise::resolve(''));
+            ->andReturn(Promise\resolve(''));
 
         $promise = $this->executor->execute('example.com', 'A', 1, -1);
 
         $promise->done($this->createCallback(0), $this->createCallback(1));
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testServerDoesNotRespond()
@@ -295,11 +295,11 @@ class ExecutorTest extends TestCase
 
         $this->client->shouldReceive('write')
             ->andReturnUsing(function ($data) {
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             });
 
         $this->client->shouldReceive('read')
-            ->andReturn(Promise::reject(new TimeoutException('Socket timed out.')));
+            ->andReturn(Promise\reject(new TimeoutException('Socket timed out.')));
 
         $promise = $this->executor->execute('example.com', 'A', $timeout, 0);
 
@@ -309,7 +309,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testServerDoesNotRespondWithRetries()
@@ -319,12 +319,12 @@ class ExecutorTest extends TestCase
 
         $this->client->shouldReceive('write')
             ->andReturnUsing(function ($data) {
-                return Promise::resolve(strlen($data));
+                return Promise\resolve(strlen($data));
             });
 
         $this->client->shouldReceive('read')
             ->times(3)
-            ->andReturn(Promise::reject(new TimeoutException('Socket timed out.')));
+            ->andReturn(Promise\reject(new TimeoutException('Socket timed out.')));
 
         $promise = $this->executor->execute('example.com', 'A', $timeout, $retries);
 
@@ -334,7 +334,7 @@ class ExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -359,9 +359,9 @@ class ExecutorTest extends TestCase
                 static $initial = true;
                 if ($initial) {
                     $initial = false;
-                    return Promise::reject(new TimeoutException('Socket timed out.'));
+                    return Promise\reject(new TimeoutException('Socket timed out.'));
                 }
-                return Promise::resolve($id . substr(base64_decode($response), self::ID_LENGTH));
+                return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
         $promise = $this->executor->execute($domain, 'A', $timeout, $retries);
@@ -372,6 +372,6 @@ class ExecutorTest extends TestCase
 
         $promise->done($callback);
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Executor/ExecutorTest.php
+++ b/tests/Executor/ExecutorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Icicle\Tests\Dns\Executor;
 
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Exception\InvalidTypeException;
 use Icicle\Dns\Exception\ResponseIdException;
 use Icicle\Dns\Executor\Executor;
@@ -86,7 +87,7 @@ class ExecutorTest extends TestCase
     {
         $type = -1;
 
-        $promise = $this->executor->execute('example.com', $type);
+        $coroutine = new Coroutine($this->executor->execute('example.com', $type));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -95,7 +96,7 @@ class ExecutorTest extends TestCase
                 $this->assertSame($type, $exception->getType());
             }));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -104,7 +105,7 @@ class ExecutorTest extends TestCase
     {
         $type = 'Q';
 
-        $promise = $this->executor->execute('example.com', $type);
+        $coroutine = new Coroutine($this->executor->execute('example.com', $type));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -113,7 +114,7 @@ class ExecutorTest extends TestCase
                 $this->assertSame($type, $exception->getType());
             }));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -132,7 +133,7 @@ class ExecutorTest extends TestCase
                 return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
-        $promise = $this->executor->execute($domain, $type);
+        $coroutine = new Coroutine($this->executor->execute($domain, $type));
 
         $callback = function (Message $message) use ($answers, $authority) {
             $this->assertInstanceOf('LibDNS\Messages\Message', $message);
@@ -156,7 +157,7 @@ class ExecutorTest extends TestCase
             }
         };
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run();
     }
@@ -202,13 +203,13 @@ class ExecutorTest extends TestCase
                 return Promise\resolve($id . substr(base64_decode($response), 2));
             });
 
-        $promise = $this->executor->execute($domain, 'A');
+        $coroutine = new Coroutine($this->executor->execute($domain, 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Dns\Exception\ExceptionInterface'));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -233,7 +234,7 @@ class ExecutorTest extends TestCase
                 return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
-        $promise = $this->executor->execute($domain, 'NS');
+        $coroutine = new Coroutine($this->executor->execute($domain, 'NS'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -243,7 +244,7 @@ class ExecutorTest extends TestCase
                 $this->assertInstanceOf('LibDNS\Messages\Message', $response);
             }));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -258,13 +259,13 @@ class ExecutorTest extends TestCase
         $this->client->shouldReceive('read')
             ->andReturn(Promise\resolve(''));
 
-        $promise = $this->executor->execute('example.com', 'A');
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Dns\Exception\FailureException'));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -282,9 +283,9 @@ class ExecutorTest extends TestCase
         $this->client->shouldReceive('read')
             ->andReturn(Promise\resolve(''));
 
-        $promise = $this->executor->execute('example.com', 'A', 1, -1);
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A', 1, -1));
 
-        $promise->done($this->createCallback(0), $this->createCallback(1));
+        $coroutine->done($this->createCallback(0), $this->createCallback(1));
 
         Loop\run();
     }
@@ -301,13 +302,13 @@ class ExecutorTest extends TestCase
         $this->client->shouldReceive('read')
             ->andReturn(Promise\reject(new TimeoutException('Socket timed out.')));
 
-        $promise = $this->executor->execute('example.com', 'A', $timeout, 0);
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A', $timeout, 0));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Dns\Exception\NoResponseException'));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -326,13 +327,13 @@ class ExecutorTest extends TestCase
             ->times(3)
             ->andReturn(Promise\reject(new TimeoutException('Socket timed out.')));
 
-        $promise = $this->executor->execute('example.com', 'A', $timeout, $retries);
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A', $timeout, $retries));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Dns\Exception\NoResponseException'));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -364,13 +365,13 @@ class ExecutorTest extends TestCase
                 return Promise\resolve($id . substr(base64_decode($response), self::ID_LENGTH));
             });
 
-        $promise = $this->executor->execute($domain, 'A', $timeout, $retries);
+        $coroutine = new Coroutine($this->executor->execute($domain, 'A', $timeout, $retries));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('LibDNS\Messages\Message'));
 
-        $promise->done($callback);
+        $coroutine->done($callback);
 
         Loop\run();
     }

--- a/tests/Executor/MultiExecutorTest.php
+++ b/tests/Executor/MultiExecutorTest.php
@@ -3,8 +3,8 @@ namespace Icicle\Tests\Dns\Executor;
 
 use Icicle\Dns\Exception\MessageException;
 use Icicle\Dns\Executor\MultiExecutor;
-use Icicle\Loop\Loop;
-use Icicle\Promise\Promise;
+use Icicle\Loop;
+use Icicle\Promise;
 use Icicle\Tests\Dns\TestCase;
 
 class MultiExecutorTest extends TestCase
@@ -37,7 +37,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function execute($type, $domain, $request, $response, array $answers = null, array $authority = null)
@@ -49,7 +49,7 @@ class MultiExecutorTest extends TestCase
         $executor->expects($this->once())
             ->method('execute')
             ->with($domain, $type)
-            ->will($this->returnValue(Promise::resolve($message)));
+            ->will($this->returnValue(Promise\resolve($message)));
 
         $this->executor->add($executor);
 
@@ -61,7 +61,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -94,7 +94,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(Promise::reject(new MessageException())));
+            ->will($this->returnValue(Promise\reject(new MessageException())));
 
         $this->executor->add($executor);
 
@@ -102,7 +102,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(Promise::resolve($this->createMessage())));
+            ->will($this->returnValue(Promise\resolve($this->createMessage())));
 
         $this->executor->add($executor);
 
@@ -114,7 +114,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testNextRequestUsesLastRespondingExecutor()
@@ -123,7 +123,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(Promise::reject(new MessageException())));
+            ->will($this->returnValue(Promise\reject(new MessageException())));
 
         $this->executor->add($executor);
 
@@ -131,7 +131,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->exactly(2))
             ->method('execute')
-            ->will($this->returnValue(Promise::resolve($this->createMessage())));
+            ->will($this->returnValue(Promise\resolve($this->createMessage())));
 
         $this->executor->add($executor);
 
@@ -143,7 +143,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run(); // Should shift first executor to back of list.
+        Loop\run(); // Should shift first executor to back of list.
 
         $promise = $this->executor->execute('example.org', 'A');
 
@@ -153,7 +153,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run(); // Should call second executor first.
+        Loop\run(); // Should call second executor first.
     }
 
     public function testRetries()
@@ -166,7 +166,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->exactly($retries + 1))
             ->method('execute')
-            ->will($this->returnValue(Promise::reject($exception)));
+            ->will($this->returnValue(Promise\reject($exception)));
 
         $this->executor->add($executor);
 
@@ -174,7 +174,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->exactly($retries + 1))
             ->method('execute')
-            ->will($this->returnValue(Promise::reject($exception)));
+            ->will($this->returnValue(Promise\reject($exception)));
 
         $this->executor->add($executor);
 
@@ -186,7 +186,7 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -201,7 +201,7 @@ class MultiExecutorTest extends TestCase
 
         $executor->expects($this->once())
             ->method('execute')
-            ->will($this->returnValue(Promise::reject($exception)));
+            ->will($this->returnValue(Promise\reject($exception)));
 
         $this->executor->add($executor);
 
@@ -213,6 +213,6 @@ class MultiExecutorTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Executor/MultiExecutorTest.php
+++ b/tests/Executor/MultiExecutorTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Icicle\Tests\Dns\Executor;
 
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Exception\MessageException;
 use Icicle\Dns\Executor\MultiExecutor;
 use Icicle\Loop;
@@ -29,13 +30,13 @@ class MultiExecutorTest extends TestCase
 
     public function testNoExecutors()
     {
-        $promise = $this->executor->execute('example.com', 'A');
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('Icicle\Dns\Exception\LogicException'));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -53,13 +54,13 @@ class MultiExecutorTest extends TestCase
 
         $this->executor->add($executor);
 
-        $promise = $this->executor->execute($domain, $type);
+        $coroutine = new Coroutine($this->executor->execute($domain, $type));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->identicalTo($message));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run();
     }
@@ -106,13 +107,13 @@ class MultiExecutorTest extends TestCase
 
         $this->executor->add($executor);
 
-        $promise = $this->executor->execute('example.com', 'A');
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('LibDNS\Messages\Message'));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run();
     }
@@ -135,23 +136,23 @@ class MultiExecutorTest extends TestCase
 
         $this->executor->add($executor);
 
-        $promise = $this->executor->execute('example.com', 'A');
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('LibDNS\Messages\Message'));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run(); // Should shift first executor to back of list.
 
-        $promise = $this->executor->execute('example.org', 'A');
+        $coroutine = new Coroutine($this->executor->execute('example.org', 'A'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->isInstanceOf('LibDNS\Messages\Message'));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run(); // Should call second executor first.
     }
@@ -178,13 +179,13 @@ class MultiExecutorTest extends TestCase
 
         $this->executor->add($executor);
 
-        $promise = $this->executor->execute('example.com', 'A', $timeout, $retries);
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A', $timeout, $retries));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->identicalTo($exception));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -205,13 +206,13 @@ class MultiExecutorTest extends TestCase
 
         $this->executor->add($executor);
 
-        $promise = $this->executor->execute('example.com', 'A', $timeout, -1);
+        $coroutine = new Coroutine($this->executor->execute('example.com', 'A', $timeout, -1));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->identicalTo($exception));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -1,6 +1,7 @@
 <?php
 namespace Icicle\Tests\Dns\Resolver;
 
+use Icicle\Coroutine\Coroutine;
 use Icicle\Dns\Exception\NotFoundException;
 use Icicle\Dns\Resolver\Resolver;
 use Icicle\Loop;
@@ -44,7 +45,7 @@ class ResolverTest extends TestCase
             ->with(Mockery::mustBe($domain), Mockery::mustBe(ResourceQTypes::A), Mockery::any(), Mockery::type('integer'))
             ->andReturn($this->createMessage($answers, $authority));
 
-        $promise = $this->resolver->resolve($domain);
+        $coroutine = new Coroutine($this->resolver->resolve($domain));
 
         $result = [];
 
@@ -58,7 +59,7 @@ class ResolverTest extends TestCase
         $callback->method('__invoke')
             ->with($this->equalTo($result));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run();
     }
@@ -73,7 +74,7 @@ class ResolverTest extends TestCase
         $this->executor->shouldReceive('execute')
             ->andReturn($this->createMessage());
 
-        $promise = $this->resolver->resolve($domain);
+        $coroutine = new Coroutine($this->resolver->resolve($domain));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
@@ -83,7 +84,7 @@ class ResolverTest extends TestCase
                 $this->assertSame(ResourceQTypes::A, $exception->getType());
             }));
 
-        $promise->done($this->createCallback(0), $callback);
+        $coroutine->done($this->createCallback(0), $callback);
 
         Loop\run();
     }
@@ -93,13 +94,13 @@ class ResolverTest extends TestCase
         $this->executor->shouldReceive('execute')
             ->never();
 
-        $promise = $this->resolver->resolve('localhost');
+        $coroutine = new Coroutine($this->resolver->resolve('localhost'));
 
         $callback = $this->createCallback(1);
         $callback->method('__invoke')
             ->with($this->equalTo(['127.0.0.1']));
 
-        $promise->done($callback, $this->createCallback(0));
+        $coroutine->done($callback, $this->createCallback(0));
 
         Loop\run();
     }

--- a/tests/Resolver/ResolverTest.php
+++ b/tests/Resolver/ResolverTest.php
@@ -3,7 +3,7 @@ namespace Icicle\Tests\Dns\Resolver;
 
 use Icicle\Dns\Exception\NotFoundException;
 use Icicle\Dns\Resolver\Resolver;
-use Icicle\Loop\Loop;
+use Icicle\Loop;
 use Icicle\Tests\Dns\TestCase;
 use LibDNS\Records\ResourceQTypes;
 use Mockery;
@@ -60,7 +60,7 @@ class ResolverTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 
     /**
@@ -85,7 +85,7 @@ class ResolverTest extends TestCase
 
         $promise->done($this->createCallback(0), $callback);
 
-        Loop::run();
+        Loop\run();
     }
 
     public function testLocalhost()
@@ -101,6 +101,6 @@ class ResolverTest extends TestCase
 
         $promise->done($callback, $this->createCallback(0));
 
-        Loop::run();
+        Loop\run();
     }
 }

--- a/tests/Stub/CallbackStub.php
+++ b/tests/Stub/CallbackStub.php
@@ -1,0 +1,7 @@
+<?php
+namespace Icicle\Tests\Dns\Stub;
+
+class CallbackStub
+{
+    public function __invoke() {}
+}

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -6,8 +6,25 @@ use LibDNS\Messages\MessageTypes;
 use LibDNS\Records\ResourceBuilderFactory;
 use Symfony\Component\Yaml\Yaml;
 
-class TestCase extends \Icicle\Tests\TestCase
+abstract class TestCase extends \PHPUnit_Framework_TestCase
 {
+    /**
+     * Creates a callback that must be called $count times or the test will fail.
+     *
+     * @param   int $count Number of times the callback should be called.
+     *
+     * @return  callable Object that is callable and expects to be called the given number of times.
+     */
+    public function createCallback($count)
+    {
+        $mock = $this->getMock('Icicle\Tests\Dns\Stub\CallbackStub');
+
+        $mock->expects($this->exactly($count))
+            ->method('__invoke');
+
+        return $mock;
+    }
+
     /**
      * @return  array Array of A record requests and responses.
      */


### PR DESCRIPTION
Switch `ExecutorInterface::execute()` and `ResolverInterface::resolve()` to return Generators instead of promises to support `yield from` in PHP 7.
